### PR TITLE
Update vppMath.cpp

### DIFF
--- a/src/vppMath.cpp
+++ b/src/vppMath.cpp
@@ -58,7 +58,7 @@ std::vector<float> vppMath::bubbleSort(std::vector<float> a)
 {
 
 	bool notSorted = false;
-	int lastSorted = a.size() - 1;
+	size_t lastSorted = a.size() - 1;
 
 	int swaps = 0;
 	while (!notSorted) {


### PR DESCRIPTION
Prevents warnings  [size_t] 
Warnings: 'var' : conversion from 'size_t' to 'type', possible loss of data